### PR TITLE
Update to latest Zig

### DIFF
--- a/.github/workflows/actions-build.sh
+++ b/.github/workflows/actions-build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-zig build \
-	-Doptimize=ReleaseSafe -Dglslc="$PWD/shaderc/bin/glslc" \
-	-Dsuffix -Dstrip -Dtimestamp -Dtarget="$1"
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,39 +1,28 @@
 name: Build native binaries
 
-on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - '**.zig'
-      - '.github/**'
+on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-build
-          path: |
-            zig-cache
-            ~/.cache/deps-zig
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: mlugg/setup-zig@v1
+        with: { version: "0.13.0" }
 
-      - uses: actions/checkout@v2
-      - uses: goto-bus-stop/setup-zig@v1
-        with: {version: "0.11.0"}
-
-      # TODO: figure out a way to cache this
       - name: Install ShaderC
-        run: ./.github/workflows/install-shaderc.sh
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y glslc
 
       - name: Build for x86_64 Linux glibc
-        run: ./.github/workflows/actions-build.sh x86_64-linux-gnu
+        run: zig build -Doptimize=ReleaseSafe -Dsuffix -Dstrip -Dtimestamp -Dtarget=x86_64-linux-gnu
       - name: Build for x86_64 Linux musl
-        run: ./.github/workflows/actions-build.sh x86_64-linux-musl
+        run: zig build -Doptimize=ReleaseSafe -Dsuffix -Dstrip -Dtimestamp -Dtarget=x86_64-linux-musl
       - name: Build for x86_64 Windows
-        run: ./.github/workflows/actions-build.sh x86_64-windows
+        run: zig build -Doptimize=ReleaseSafe -Dsuffix -Dstrip -Dtimestamp -Dtarget=x86_64-windows
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/install-shaderc.sh
+++ b/.github/workflows/install-shaderc.sh
@@ -1,6 +1,0 @@
-#!/bin/sh -e
-ci_page=https://storage.googleapis.com/shaderc/badges/build_link_linux_clang_release.html
-latest_build=$(curl -sSL "$ci_page" | sed 's/.*url=\([^"]*\)".*/\1/;q')
-curl -sSLo shaderc.tar.gz "$latest_build"
-tar -xzf shaderc.tar.gz
-mv install shaderc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,18 +1,26 @@
 .{
     .name = "slimy",
     .version = "0.1.0-dev",
+    .paths = .{
+        "LICENSE",
+        "README.md",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "web",
+    },
     .dependencies = .{
         .optz = .{
-            .url = "https://github.com/silversquirl/optz/archive/a57f38365d85a8c1151171a7e3a715ed285e2a9d.tar.gz",
-            .hash = "12200ddfa43ada90f0a56d8cd1664c91321001a30c1bbb5a6ac6d405161c4750d6d2",
+            .url = "https://github.com/silversquirl/optz/archive/63c1c02ecbbfe18fa898b5b86dbee0e5e30df099.tar.gz",
+            .hash = "12200ca26c64345c3fd64caf744205c05b48abe11353261252b562c7d721a451589f",
         },
         .cpuinfo = .{
-            .url = "https://github.com/silversquirl/cpuinfo-zig/archive/bf816de759cf02c95ee9d94e7e7ab3e373a7286f.tar.gz",
-            .hash = "1220e168bbe411e4a92ffb194a7cf353997e69af530ca9ed4b4411c178948b340995",
+            .url = "https://github.com/silversquirl/cpuinfo-zig/archive/7a7d5aea11addee3b81baa9195ef84593376d39a.tar.gz",
+            .hash = "122048b51d1cdd9dd16c93927a47e9ee3ed7756d1060d33442749ce332b176ef0604",
         },
         .zcompute = .{
-            .url = "https://github.com/silversquirl/zcompute/archive/60312ae55c6447a387462ab0212b7c163dfd50d3.tar.gz",
-            .hash = "12206a1edb5a051dbdbdd106bdc19ac3f1f1237de076e80fb7325d5a98a98f8df54b",
+            .url = "https://github.com/silversquirl/zcompute/archive/321f260b3170e1a66cf9abf29f4d0ae5115b2185.tar.gz",
+            .hash = "12202fe573ff7fd505d2e00dc1c8eaa2393efb6ae1806abed15254c311d473b9eff2",
         },
     },
 }

--- a/src/gpu.zig
+++ b/src/gpu.zig
@@ -39,7 +39,7 @@ pub const Context = struct {
             return error.VulkanInit;
         };
 
-        self.shad = Shader.initBytes(arena.allocator(), &self.ctx, @embedFile("shader/search.spv")) catch |err| {
+        self.shad = Shader.initBytes(arena.allocator(), &self.ctx, @embedFile("search_spv")) catch |err| {
             log.err("Shader init error: {s}", .{@errorName(err)});
             return error.ShaderInit;
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -203,7 +203,7 @@ test "output context" {
         .progress = false,
     });
 
-    var pipe = try std.os.pipe();
+    const pipe = try std.os.pipe();
     var readf = std.fs.File{ .handle = pipe[0] };
     defer readf.close();
     var writef = std.fs.File{ .handle = pipe[1] };

--- a/src/slimy.zig
+++ b/src/slimy.zig
@@ -57,7 +57,6 @@ pub const Result = struct {
 };
 
 test {
-    @import("std").testing.refAllDecls(@This());
-    @import("std").testing.refAllDecls(cpu);
-    @import("std").testing.refAllDecls(gpu);
+    _ = cpu;
+    _ = gpu;
 }


### PR DESCRIPTION
Tested on Zig 0.14.0-dev.367+a57479afc.

Only non-trivial migration point is that I made the `glslc` integration actually use the cache system correctly. The compiled SPIR-V shader is now exposed through a module `search_spv` which is used with `@embedFile("search_spv")`.

Resolves: #2